### PR TITLE
Do not crash Syncsketch addon if it cannot connect to the Syncsketch server due to wrong server or credentials

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,4 +1,3 @@
-import json
 from pprint import pformat
 import socket
 from typing import Type, Any

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -108,8 +108,16 @@ class SyncsketchAddon(BaseServerAddon):
             "Content-Type": "application/json",
         }
 
-        existing_webhooks = requests.request(
-            "GET", syncsketch_endpoint, headers=headers)
+        try:
+            existing_webhooks = requests.request(
+                "GET", syncsketch_endpoint, headers=headers)
+        except requests.exceptions.ConnectionError:
+            # This could happen if the SyncSketch API is not reachable
+            # with e.g. authentication issues, or the server is down.
+            # Usually with a "Max retries exceeded with url" message.
+            logging.error(
+                f"SyncSketch API connection error at: {syncsketch_endpoint}")
+            return
 
         if existing_webhooks.status_code == 404:
             logging.error(


### PR DESCRIPTION
## Changelog Description

Do not crash Syncsketch addon if it cannot connect to the Syncsketch server due to wrong server or credentials


## Additional info

Previously this would error with:
```python
2024-10-25 13:52:02 2024-10-25 11:52:02 ERROR      server          Error during syncsketch 0.2.0+dev setup
2024-10-25 13:52:02 
2024-10-25 13:52:02     Traceback (most recent call last):
2024-10-25 13:52:02       File "/usr/local/lib/python3.11/site-packages/requests/models.py", line 974, in json
2024-10-25 13:52:02         return complexjson.loads(self.text, **kwargs)
2024-10-25 13:52:02                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-10-25 13:52:02       File "/usr/local/lib/python3.11/json/__init__.py", line 346, in loads
2024-10-25 13:52:02         return _default_decoder.decode(s)
2024-10-25 13:52:02                ^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-10-25 13:52:02       File "/usr/local/lib/python3.11/json/decoder.py", line 337, in decode
2024-10-25 13:52:02         obj, end = self.raw_decode(s, idx=_w(s, 0).end())
2024-10-25 13:52:02                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-10-25 13:52:02       File "/usr/local/lib/python3.11/json/decoder.py", line 355, in raw_decode
2024-10-25 13:52:02         raise JSONDecodeError("Expecting value", s, err.value) from None
2024-10-25 13:52:02     json.decoder.JSONDecodeError: Expecting value: line 3 column 1 (char 2)
2024-10-25 13:52:02     
2024-10-25 13:52:02     During handling of the above exception, another exception occurred:
2024-10-25 13:52:02     
2024-10-25 13:52:02     Traceback (most recent call last):
2024-10-25 13:52:02       File "/backend/ayon_server/api/server.py", line 448, in startup_event
2024-10-25 13:52:02         await version.setup()
2024-10-25 13:52:02       File "/addons/syncsketch/0.2.0+dev/server/__init__.py", line 47, in setup
2024-10-25 13:52:02         await self.create_syncsketch_webhook()
2024-10-25 13:52:02       File "/addons/syncsketch/0.2.0+dev/server/__init__.py", line 121, in create_syncsketch_webhook
2024-10-25 13:52:02         if existing_webhooks.json():
2024-10-25 13:52:02            ^^^^^^^^^^^^^^^^^^^^^^^^
2024-10-25 13:52:02       File "/usr/local/lib/python3.11/site-packages/requests/models.py", line 978, in json
2024-10-25 13:52:02         raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
2024-10-25 13:52:02     requests.exceptions.JSONDecodeError: Expecting value: line 3 column 1 (char 2)
```

## Testing notes:

1. Set up all required credentials and server - but to the wrong address that server can't connect to
2. Restart server
3. Addon should still work and not be broken.
